### PR TITLE
chore: update thin-edge.io version

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -7,7 +7,7 @@ on:
       - ci
 
 env:
-  PI_BASE_IMAGE: "https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64-lite.img.xz"
+  PI_BASE_IMAGE: "https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-10-10/2023-10-10-raspios-bookworm-arm64-lite.img.xz"
 
 jobs:  
   bake-image:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Build the image
 
     ```sh
-    ./run-bakery extract https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64-lite.img.xz build/base.tar
+    ./run-bakery extract https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-10-10/2023-10-10-raspios-bookworm-arm64-lite.img.xz build/base.tar
     ./run-bakery customize build/base.tar build/customized.tar
     ./run-bakery bake build/customized.tar build/customized.img
     ```

--- a/recipes/set-hostname-from-serial/files/set-hostname.sh
+++ b/recipes/set-hostname-from-serial/files/set-hostname.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+HARDWARE=$(cat /proc/cpuinfo  | grep Serial | cut -d: -f2 | xargs)
+SERIAL_NO=$(cat /proc/cpuinfo  | grep Serial | cut -d: -f2 | xargs)
+#MODEL=$(cat /proc/cpuinfo  | grep Model | cut -d: -f2- | xargs)
+
+MODEL_HUMAN=
+IMAGE_FAMILY=rugpi
+
+case "$HARDWARE" in
+    Raspberry\ Pi\ 5*)
+        MODEL_HUMAN=rpi5
+        ;;
+    Raspberry\ Pi\ 4*)
+        MODEL_HUMAN=rpi4
+        ;;
+    Raspberry\ Pi\ 3*)
+        MODEL_HUMAN=rpi3
+        ;;
+    Raspberry\ Pi\ 2\ Rev*)
+        MODEL_HUMAN=rpi2
+        ;;
+    Raspberry\ Pi\ Model*)
+        MODEL_HUMAN=rpi1
+        ;;
+    Raspberry\ Pi\ Zero\ 2\ W\ Rev*)
+        MODEL_HUMAN=rpizero2
+        ;;
+    Raspberry\ Pi\ Zero\ W\ Rev*)
+        MODEL_HUMAN=rpizero
+        ;;
+    *)
+        MODEL_HUMAN=unknown
+        ;;
+esac
+
+echo "${MODEL_HUMAN}_${IMAGE_FAMILY}_${SERIAL_NO}" > /etc/hostname
+
+# cat > /etc/hosts << EOF
+# 127.0.0.1       localhost
+# ::1             localhost ip6-localhost ip6-loopback
+# ff02::1         ip6-allnodes
+# ff02::2         ip6-allrouters
+# EOF

--- a/recipes/set-hostname-from-serial/files/startup-hostname.service
+++ b/recipes/set-hostname-from-serial/files/startup-hostname.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set hostname on startup
+Wants=network-pre.target
+Before=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/set-hostname.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes/set-hostname-from-serial/recipe.toml
+++ b/recipes/set-hostname-from-serial/recipe.toml
@@ -1,0 +1,2 @@
+description = "sets the hostname from serial number"
+priority = 90_000

--- a/recipes/set-hostname-from-serial/steps/00-install.sh
+++ b/recipes/set-hostname-from-serial/steps/00-install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+install -D -m 755 "${RECIPE_DIR}/files/set-hostname.sh" -t /usr/bin/
+install -D -m 644 "${RECIPE_DIR}/files/startup-hostname.service" -t /usr/lib/systemd/system/
+
+systemctl enable startup-hostname.service

--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -1,19 +1,17 @@
 #!/bin/bash -e
 
 # install thin-edge.io
-curl -fsSL https://thin-edge.io/install.sh | sh -s
+curl -fsSL https://thin-edge.io/install.sh | sh -s -- --channel main
 
 # Install collectd
-apt-get install -y --no-install-recommends collectd-core mosquitto-clients
-cp /etc/tedge/contrib/collectd/collectd.conf /etc/collectd/collectd.conf
+apt-get install -y --no-install-recommends \
+    mosquitto-clients \
+    c8y-command-plugin \
+    tedge-collectd-setup
 
 # custom tedge configuration
 tedge config set apt.name "(tedge|c8y|python|wget|vim|curl|apt|mosquitto|ssh|sudo).*"
 
-# setup thin-edge.io community repository
-curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/setup.deb.sh' | bash
-apt-get update
-apt-get install -y c8y-command-plugin
 
 # Enable network manager by default
 systemctl enable NetworkManager || true

--- a/rugpi-bakery.toml
+++ b/rugpi-bakery.toml
@@ -1,7 +1,4 @@
-recipes = ["set-hostname", "persist-root-home", "ssh", "zsh"]
-
-[parameters.set-hostname]
-hostname = "pippin.local"
+recipes = ["set-hostname-from-serial", "persist-root-home", "ssh", "zsh"]
 
 [parameters.apt-cleanup]
 autoremove = true


### PR DESCRIPTION
Changes:
* set hostname from hardware information (e.g. serial number)
* update to latest thin-edge.io and use latest MQTT v1 api