### PR TITLE
override pi-cleanup recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@
 2. Flash the `build/image.img` image to the Raspberry Pi
 
 For further information, checkout the [Rugpi quick start guide](https://oss.silitics.com/rugpi/docs/getting-started).
+
+* [ ] Sensible configuration file defaults
+    * configuration
+    * log
+* [ ] Set hostname based on hardware

--- a/recipes/pi-cleanup-fix/recipe.toml
+++ b/recipes/pi-cleanup-fix/recipe.toml
@@ -1,0 +1,3 @@
+description = "remove unnecessary Raspberry Pi OS functionality"
+priority = 700_000  # Execute very early.
+default = true

--- a/recipes/pi-cleanup-fix/steps/00-install.sh
+++ b/recipes/pi-cleanup-fix/steps/00-install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+systemctl disable userconfig ||:
+systemctl disable unattended-upgrades.service ||:
+systemctl disable resize2fs_once ||:
+
+apt-get purge -y userconf-pi
+rm -f /etc/ssh/sshd_config.d/rename_user.conf

--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -22,3 +22,6 @@ systemctl enable tedge-mapper-c8y
 systemctl enable tedge-mapper-collectd
 systemctl enable collectd
 
+# TODO: should overlay be persisted by default, otherwise someone can accidentally disable a service
+# and leave it off, however otherwise it is a bit harder to control services during runtime
+#rugpi-ctrl state overlay set-persist true

--- a/rugpi-bakery.toml
+++ b/rugpi-bakery.toml
@@ -1,4 +1,5 @@
 recipes = ["set-hostname-from-serial", "persist-root-home", "ssh", "zsh"]
+exclude = ["pi-cleanup"]
 
 [parameters.apt-cleanup]
 autoremove = true


### PR DESCRIPTION
override pi-cleanup recipe with custom to fix an issue with disabling a non existent service