### PR TITLE
Improve healthcheck logger by adding timestamp prefixes

### DIFF
--- a/recipes/rugpi-auto-rollback/files/healthcheck.sh
+++ b/recipes/rugpi-auto-rollback/files/healthcheck.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 set -eu
-LOG_FILE=/data/healthcheck.log
+LOG_FILE=/etc/tedge/healthcheck.log
+
+# Perform simple log rotation, only keep last 200 lines
+if [ -f "$LOG_FILE" ]; then
+    tail -200 "$LOG_FILE" > "${LOG_FILE}.tmp" ||true
+    mv "${LOG_FILE}.tmp" "$LOG_FILE" ||true
+fi
 
 _NEWLINE=$(printf '\n')
 log() {
     message="$(date -Iseconds || date --iso-8601=seconds) $*"
     echo "$message"
+    # Don't stop if writing to log fails (non critical error)
     echo "$message" 2>/dev/null >> "$LOG_FILE" ||true
 }
 

--- a/recipes/rugpi-auto-rollback/files/rugpi-auto-rollback.service
+++ b/recipes/rugpi-auto-rollback/files/rugpi-auto-rollback.service
@@ -4,8 +4,6 @@ Description=Rollback the currently booted system if thin-edge.io cannot connect 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/healthcheck.sh
-StandardOutput=append:/etc/tedge/healthcheck.out.log
-StandardError=append:/etc/tedge/healthcheck.err.log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
healtcheck logger improvements to make it easier to debug across failed firmware updates
* include timestamp in log entries
* log rotate (keeping only last 200 lines)