### PR TITLE
feat: include tedge-inventory-plugin in image

### DIFF
--- a/recipes/rugpi-auto-rollback/files/healthcheck.sh
+++ b/recipes/rugpi-auto-rollback/files/healthcheck.sh
@@ -91,22 +91,6 @@ collect_rugpi() {
     tedge mqtt pub -q 1 "$TARGET/e/device_boot" "$PAYLOAD" ||:
 }
 
-collect_os_info() {
-    if [ -z "$DEVICE_ID" ]; then
-        return 0
-    fi
-
-    # Collect Operating System information
-    if [ -f /etc/os-release ]; then
-        # shellcheck disable=SC1091
-        . /etc/os-release ||:
-
-        # publish to tedge api which is not yet supported
-        PAYLOAD=$(printf '{"family":"%s","version":"%s"}' "$NAME" "${VERSION:-$VERSION_ID}")
-        tedge mqtt pub --retain "$TARGET/twin/device_OS" "$PAYLOAD" ||:
-    fi
-}
-
 try_wait_for_broker() {
     # Try to wait until the broker is ready before publishing data.
     # Proceed anyway if it still is not ready have N tries
@@ -126,7 +110,6 @@ try_wait_for_broker() {
 publish_system_info() {
     try_wait_for_broker
     collect_rugpi
-    collect_os_info
 }
 
 main() {

--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -8,7 +8,8 @@ apt-get install -y --no-install-recommends \
     mosquitto-clients \
     c8y-command-plugin \
     tedge-collectd-setup \
-    tedge-monit-setup
+    tedge-monit-setup \
+    tedge-inventory-plugin
 
 # custom tedge configuration
 tedge config set apt.name "(tedge|c8y|python|wget|vim|curl|apt|mosquitto|ssh|sudo).*"


### PR DESCRIPTION
Add new [tedge-inventory-plugin](https://github.com/thin-edge/tedge-inventory-plugin) which publishes information about the hardware and operating system on startup