### PR TITLE
ci(armhf): build u-boot-armhf-containers image

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -48,6 +48,7 @@ jobs:
           - { image: u-boot }
           - { image: u-boot-containers }
           - { image: u-boot-armhf }
+          - { image: u-boot-armhf-containers }
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Build `u-boot-armhf-containers` image so it can be included in the release to make it easier for users to experiment with armhf (32 bit) based images, for example if they can't use the arm64 variant due to upgrade reasons.