### PR TITLE
feat: update rugix-bakery to 0.9 and update to Debian trixie

### DIFF
--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -49,6 +49,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
+          - { system: tedge-debian-13-efi-arm64, runner: ubuntu-24.04-arm }
+          - { system: tedge-debian-13-efi-amd64, runner: ubuntu-latest }
           - { system: tedge-debian-12-efi-arm64, runner: ubuntu-24.04-arm }
           - { system: tedge-debian-12-efi-amd64, runner: ubuntu-latest }
           - { system: tedge-raspios-arm64-tryboot-pi4, runner: ubuntu-24.04-arm }

--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    branches: [main]
     tags:
       - "*"
 

--- a/.github/workflows/bake-image.yml
+++ b/.github/workflows/bake-image.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    branches: [feat-rugix]
+    branches: [main]
     tags:
       - "*"
 
@@ -17,7 +17,7 @@ jobs:
       version: ${{ steps.info.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: taiki-e/install-action@just
@@ -43,6 +43,8 @@ jobs:
     env:
       IMAGE_NAME: ${{ matrix.job.system }}_${{ needs.info.outputs.version }}
       VERSION: ${{needs.info.outputs.version}}
+      DOCKER: ${{ matrix.job.engine || 'podman' }}
+      SUDO: ${{ matrix.job.sudo || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,13 +54,16 @@ jobs:
           - { system: tedge-raspios-arm64-tryboot-pi4, runner: ubuntu-24.04-arm }
           - { system: tedge-raspios-arm64-tryboot, runner: ubuntu-24.04-arm }
           - { system: tedge-raspios-arm64, runner: ubuntu-24.04-arm }
-          - { system: tedge-raspios-armhf, runner: ubuntu-latest }
+          - { system: tedge-raspios-armhf, runner: ubuntu-latest, engine: docker, sudo: 'sudo' }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - uses: taiki-e/install-action@just
+
+      - name: Set up QEMU (binfmt)
+        uses: docker/setup-qemu-action@v4
 
       - name: Configure .env
         env:
@@ -78,13 +83,13 @@ jobs:
 
       - name: Rename artifacts
         run: |
-          sudo cp build/${{ matrix.job.system }}/system.img build/${{ matrix.job.system }}/${{ env.IMAGE_NAME }}.img
-          sudo cp build/${{ matrix.job.system }}/artifacts/sbom.txt build/${{ matrix.job.system }}/artifacts/${{ env.IMAGE_NAME }}.sbom.txt
+          $SUDO cp build/${{ matrix.job.system }}/system.img build/${{ matrix.job.system }}/${{ env.IMAGE_NAME }}.img
+          $SUDO cp build/${{ matrix.job.system }}/artifacts/sbom.txt build/${{ matrix.job.system }}/artifacts/${{ env.IMAGE_NAME }}.sbom.txt
           ls -l build/${{ matrix.job.system }}/
           ls -l build/${{ matrix.job.system }}/artifacts/
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.IMAGE_NAME }}.sbom.txt
           if-no-files-found: error
@@ -93,10 +98,10 @@ jobs:
 
       - name: Compress Image (xz)
         run: |
-          sudo xz -v "build/${{ matrix.job.system }}/${{ env.IMAGE_NAME }}.img"
+          $SUDO xz -v "build/${{ matrix.job.system }}/${{ env.IMAGE_NAME }}.img"
       
       - name: Upload Image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: image-upload-step
         with:
           name: ${{ env.IMAGE_NAME }}.img.xz
@@ -110,7 +115,7 @@ jobs:
           just SYSTEM=${{ matrix.job.system }} build-bundle ${{ env.IMAGE_NAME }}.rugixb
 
       - name: Upload Update Bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: bundle-upload-step
         with:
           name: ${{ env.IMAGE_NAME }}.rugixb
@@ -171,8 +176,8 @@ jobs:
       - bake-image
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+        uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           path: release
       - name: Show release artifacts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
       C8Y_PASSWORD: '${{ secrets.C8Y_PASSWORD }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: taiki-e/install-action@just

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build.log
 *.sbom.txt
 *.log
 *.env
+wordlist.txt
 
 # test keys
 id_rsa

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # thin-edge.io image using Rugix
 
-The repository can be used to build custom device images with thin-edge.io and [Rugix](https://oss.silitics.com/rugix/) for robust Over-The-Air (OTA) Operating System updates.
+The repository can be used to build custom device images with thin-edge.io and [Rugix](https://rugix.org/) for robust Over-The-Air (OTA) Operating System updates.
 
 ## Compatible devices
 
-Rugix can support building images for other devices than just Raspberry Pi's, however the thin-edge.io integration is currently only tested for Raspberry Pi devices. Please reach out for support if you are looking into integrating with other devices, or contact [Silitics](https://oss.silitics.com/rugix/commercial-support), the authors of Rugix.
+Rugix can support building images for other devices than just Raspberry Pi's, however the thin-edge.io integration is currently only tested for Raspberry Pi devices. Please reach out for support if you are looking into integrating with other devices, or contact [Silitics](https://rugix.org/commercial-support), the authors of Rugix.
 
 **Using u-boot**
 
@@ -89,7 +89,7 @@ To run the build tasks, install [just](https://just.systems/man/en/chapter_5.htm
 
     **Note:** A Rugix update bundle will have the `.rugixb` suffix in its filename
 
-For further information on Rugix, checkout the [quick start guide](https://oss.silitics.com/rugix/docs/getting-started).
+For further information on Rugix, checkout the [quick start guide](https://rugix.org/docs/getting-started).
 
 
 ### Building images/bundles including thin-edge.io main

--- a/README.md
+++ b/README.md
@@ -36,9 +36,32 @@ The following system images are included in this repository.
 
 ## Building
 
-### Building an image
+### Prerequisites
 
 To run the build tasks, install [just](https://just.systems/man/en/chapter_5.html).
+
+Rugix Bakery 0.9 uses rootless Podman by default to build images. Podman must be installed and running before building.
+
+**macOS** — install Podman via Homebrew and initialize a machine:
+
+```sh
+brew install podman
+podman machine init
+# increase the default memory to >= 4GB
+podman machine set --memory 4096
+podman machine start
+```
+
+**Linux** — install Podman via your package manager (e.g. `apt install podman`). Rootless Podman should work out of the box on most distributions without any machine setup.
+
+> **Note:** After upgrading from Rugix v0.8, delete the `.rugix` and `build` directories so they are recreated with the correct ownership for rootless Podman:
+> ```sh
+> rm -rf .rugix build
+> ```
+
+### Building an image
+
+
 
 1. Clone the repository
 
@@ -156,6 +179,22 @@ just SYSTEM=tedge-raspios-armhf build-image
 ```sh
 just SYSTEM=tedge-raspios-arm64 build-image
 ```
+
+### Local VM Development
+
+Rugix supports running an image in a VM to facilitate local development without a physical device.
+
+1. Start the VM (this will build the system image if necessary):
+
+    ```sh
+    just start-vm
+    ```
+
+2. Open a new console (leaving the previous one running) and connect to the VM:
+
+    ```sh
+    just connect-vm
+    ```
 
 ## Project Tasks
 

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ DEFAULT_SYSTEM := if arch() == "aarch64" {
 
 SYSTEM := env("SYSTEM", DEFAULT_SYSTEM)
 
+# rugix version, e.g. RUGIX_VERSION=git-5667b45
+# Use git-5667b45 until rugix-bakery >=0.9.3 is released
+export RUGIX_VERSION := env_var_or_default("RUGIX_VERSION", "git-5667b45")
+
 # Default version (info only)
 export VERSION := env_var_or_default("VERSION", `date +'%Y%m%d.%H%M'`)
 

--- a/justfile
+++ b/justfile
@@ -1,10 +1,16 @@
+# Load system recipes (generated via `just gen`)
+import 'systems.just'
+
+# Use podman if available, otherwise fall back to docker (override with DOCKER env var)
+export DOCKER := env("DOCKER", `command -v podman >/dev/null 2>&1 && echo podman || echo docker`)
+
 # System image. Default to amd64 if the arch does not match
 DEFAULT_SYSTEM := if arch() == "aarch64" {
-    "tedge-debian-12-efi-arm64"
+    "tedge-debian-13-efi-arm64"
 } else if arch() == "x86_64"  {
-    "tedge-debian-12-efi-amd64"
+    "tedge-debian-13-efi-amd64"
 } else {
-    "tedge-debian-12-efi-amd64"
+    "tedge-debian-13-efi-amd64"
 }
 
 SYSTEM := env("SYSTEM", DEFAULT_SYSTEM)
@@ -15,10 +21,6 @@ export VERSION := env_var_or_default("VERSION", `date +'%Y%m%d.%H%M'`)
 # Release version id (combined name and version)
 export RELEASE_ID := env_var_or_default("RELEASE_ID", SYSTEM + "_" + VERSION)
 
-# Use ipv6 network on the host so it does not conflict with the docker in docker inside the VM
-# See https://github.com/silitics/rugix/issues/49
-DOCKER_NETWORK := "rugix-net"
-DOCKER_FLAGS := "--network=" + DOCKER_NETWORK
 
 # Generate a version name (that can be used in follow up commands)
 generate_version:
@@ -27,7 +29,6 @@ generate_version:
 prepare:
     #!/usr/bin/env bash
     if [ ! -f tests/id_rsa ]; then
-        mkdir -p tests
         ssh-keygen -t rsa -b 4096 -f tests/id_rsa -q -N ""
     fi
 
@@ -37,8 +38,6 @@ prepare:
     else
         echo "$PUB_KEY" >> .env
     fi
-
-    docker network inspect {{DOCKER_NETWORK}} >/dev/null 2>&1 || docker network create --ipv6 -o com.docker.network.enable_ipv4=false {{DOCKER_NETWORK}}
 
 # list available systems that can be built
 list-systems:
@@ -50,20 +49,15 @@ list-systems:
 
 # Install cross-platform tools
 build-setup:
-    docker run --privileged --rm tonistiigi/binfmt --install all
+    {{DOCKER}} run --privileged --rm tonistiigi/binfmt --install all
 
 # Build an image
-# Note: use default output and rename later. see https://github.com/silitics/rugix/issues/53
+# Note: use default output and rename later. see https://github.com/rugix/rugix/issues/53
 build-image: build-setup
     ./run-bakery bake image \
         --release-id "{{RELEASE_ID}}" \
         --release-version "{{VERSION}}" \
         {{SYSTEM}}
-
-    echo "Created the image successfully"
-    echo
-    echo "  build/{{SYSTEM}}/system.img"
-    echo
 
 # Build bundle (uncompressed)
 build-bundle-uncompressed OUTPUT="system.rugixb": build-setup
@@ -74,11 +68,6 @@ build-bundle-uncompressed OUTPUT="system.rugixb": build-setup
         {{SYSTEM}} \
         build/{{SYSTEM}}/{{OUTPUT}}
 
-    echo "Created the (uncompressed) bundle successfully"
-    echo
-    echo "  build/{{SYSTEM}}/{{OUTPUT}}"
-    echo
-
 # Build build (compressed)
 build-bundle OUTPUT="system.rugixb": build-setup
     ./run-bakery bake bundle \
@@ -86,15 +75,14 @@ build-bundle OUTPUT="system.rugixb": build-setup
         --release-version "{{VERSION}}" \
         {{SYSTEM}} \
         build/{{SYSTEM}}/{{OUTPUT}}
-    
-    echo "Created the (compressed) bundle successfully"
-    echo
-    echo "  build/{{SYSTEM}}/{{OUTPUT}}"
-    echo
+
+# Run integration tests
+test:
+    ./tests/run-tests.sh
 
 # Start vm
 start-vm: prepare
-    DOCKER_FLAGS="{{DOCKER_FLAGS}}" ./run-bakery run \
+    ./run-bakery run \
         --release-id "{{RELEASE_ID}}" \
         --release-version "{{VERSION}}" \
         {{SYSTEM}} ||:
@@ -104,25 +92,14 @@ connect-vm:
     [ -f ./tests/id_rsa ] && ssh-add ./tests/id_rsa
     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 root@127.0.0.1
 
-#
-# Publishing
-#
-# Publish latest image to Cumulocity
-publish:
-    cd {{justfile_directory()}} && ./scripts/upload-c8y.sh
-
-# Publish a given github release to Cumulocity (using external urls)
-publish-external tag *args="":
-    cd {{justfile_directory()}} && ./scripts/c8y-publish-release.sh {{tag}} {{args}}
-
-# Publish a given github release to Cumulocity (using external urls) but convert an existing draft to a prerelease beforehand
-publish-external-prerelease tag:
-    cd {{justfile_directory()}} && ./scripts/c8y-publish-release.sh {{tag}} --pre-release
-
-# Trigger a release (by creating a tag)
-release:
-    git tag -a "{{VERSION}}" -m "{{VERSION}}"
-    git push origin "{{VERSION}}"
-    @echo
-    @echo "Created release (tag): {{VERSION}}"
-    @echo
+# Generate just file for system images (for improved tab completion)
+generate:
+    #!/bin/sh -e
+    echo "# Auto generated: DO NOT EDIT" > systems.just
+    
+    for name in $(grep '\[systems..*]' rugix-bakery.toml | tr -d '[]' | cut -d. -f2-); do
+        echo "" >> systems.just
+        echo "# system: $name" >> systems.just
+        echo "$name type='image':" >> systems.just
+        echo "    just SYSTEM=$name build-{{{{type}}" >> systems.just
+    done

--- a/layers/tedge-debian-12-efi.toml
+++ b/layers/tedge-debian-12-efi.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-bakery-layer.schema.json
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
 parent = "tedge-debian-12"
 
 recipes = [

--- a/layers/tedge-debian-12.toml
+++ b/layers/tedge-debian-12.toml
@@ -17,6 +17,5 @@ recipes = [
     # SBOM
     "rugix-extra/simple-sbom",
 
-    "tedge-config",
     "user-packages",
 ]

--- a/layers/tedge-debian-12.toml
+++ b/layers/tedge-debian-12.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-bakery-layer.schema.json
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
 parent = "core/debian-bookworm"
 
 recipes = [

--- a/layers/tedge-debian-13-efi.toml
+++ b/layers/tedge-debian-13-efi.toml
@@ -1,0 +1,7 @@
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
+parent = "tedge-debian-13"
+
+recipes = [
+    # Setup Debian for booting via Grub.
+    "core/debian-grub-setup",
+]

--- a/layers/tedge-debian-13.toml
+++ b/layers/tedge-debian-13.toml
@@ -17,6 +17,5 @@ recipes = [
     # SBOM
     "rugix-extra/simple-sbom",
 
-    "tedge-config",
     "user-packages",
 ]

--- a/layers/tedge-debian-13.toml
+++ b/layers/tedge-debian-13.toml
@@ -1,0 +1,22 @@
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
+parent = "tedge-rugix-core/debian-13"
+
+recipes = [
+    # default tedge packages
+    "tedge-rugix-core/defaults",
+
+    # containers
+    "tedge-rugix-core/docker",
+
+    # Setup the network
+    "tedge-rugix-core/setup-network",
+
+    # PKCS11 tools
+    "tedge-rugix-core/setup-pkcs11",
+
+    # SBOM
+    "rugix-extra/simple-sbom",
+
+    "tedge-config",
+    "user-packages",
+]

--- a/layers/tedge-raspios-legacy.toml
+++ b/layers/tedge-raspios-legacy.toml
@@ -7,10 +7,6 @@ recipes = [
     "tedge-rugix-core/raspi-tpm",
     "tedge-rugix-core/setup-pkcs11",
 
-    # use avahi instead of systemd-resolved due to
-    # an issue with high cpu usage
-    "tedge-rugix-core/avahi-daemon",
-
     # containers
     # use podman as docker has deprecated support for Raspberry OS and 
     # armhf (armv6) images, see https://docs.docker.com/engine/install/raspberry-pi-os/
@@ -25,17 +21,5 @@ recipes = [
     # SBOM
     "rugix-extra/simple-sbom",
 
-    "tedge-config",
     "user-packages",
 ]
-
-# exclude specific recipes which are currently not supported on older versions
-# due to various issues
-exclude = [
-    # high cpu usage on rpi1
-    "tedge-rugix-core/systemd-resolved",
-]
-
-[parameters."tedge-config"]
-# Allow containers to reach the MQTT broker on the host
-mqtt_bind_address = "0.0.0.0"

--- a/layers/tedge-raspios-legacy.toml
+++ b/layers/tedge-raspios-legacy.toml
@@ -12,7 +12,9 @@ recipes = [
     "tedge-rugix-core/avahi-daemon",
 
     # containers
-    "tedge-rugix-core/docker",
+    # use podman as docker has deprecated support for Raspberry OS and 
+    # armhf (armv6) images, see https://docs.docker.com/engine/install/raspberry-pi-os/
+    "tedge-rugix-core/podman",
 
     # Include u-boot setup on all image
     # to avoid having to create a layer per-bootloader

--- a/layers/tedge-raspios-legacy.toml
+++ b/layers/tedge-raspios-legacy.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-bakery-layer.schema.json
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
 parent = "tedge-rugix-core/raspios"
 
 recipes = [

--- a/layers/tedge-raspios-pi4.toml
+++ b/layers/tedge-raspios-pi4.toml
@@ -1,3 +1,4 @@
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
 parent = "tedge-raspios"
 
 recipes = [

--- a/layers/tedge-raspios.toml
+++ b/layers/tedge-raspios.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-bakery-layer.schema.json
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-layer.schema.json
 parent = "tedge-rugix-core/raspios"
 
 recipes = [

--- a/layers/tedge-raspios.toml
+++ b/layers/tedge-raspios.toml
@@ -19,10 +19,5 @@ recipes = [
     # SBOM
     "rugix-extra/simple-sbom",
 
-    "tedge-config",
     "user-packages",
 ]
-
-[parameters."tedge-config"]
-# Allow containers to reach the MQTT broker on the host
-mqtt_bind_address = "0.0.0.0"

--- a/recipes/tedge-config/recipe.toml
+++ b/recipes/tedge-config/recipe.toml
@@ -1,3 +1,4 @@
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-recipe.schema.json
 description = "thin-edge.io custom configuration"
 priority = 10_000
 # Thin-edge should be set up by the parent layer.

--- a/recipes/tedge-config/recipe.toml
+++ b/recipes/tedge-config/recipe.toml
@@ -1,8 +1,0 @@
-#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-recipe.schema.json
-description = "thin-edge.io custom configuration"
-priority = 10_000
-# Thin-edge should be set up by the parent layer.
-dependencies = []
-
-[parameters]
-mqtt_bind_address = { default = "" }

--- a/recipes/tedge-config/steps/00-install.sh
+++ b/recipes/tedge-config/steps/00-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-
-if [ -n "$RECIPE_PARAM_MQTT_BIND_ADDRESS" ]; then
-    echo "Setting mqtt.bind.address to $RECIPE_PARAM_MQTT_BIND_ADDRESS" >&2
-    tedge config set mqtt.bind.address "$RECIPE_PARAM_MQTT_BIND_ADDRESS"
-fi

--- a/recipes/user-packages/recipe.toml
+++ b/recipes/user-packages/recipe.toml
@@ -1,3 +1,4 @@
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-recipe.schema.json
 description = "User packages"
 
 dependencies = [

--- a/rugix-bakery.toml
+++ b/rugix-bakery.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-bakery-project.schema.json
+#:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-project.schema.json
 [repositories]
 rugix-extra = { git = "https://github.com/silitics/rugix-extra", branch = "main" }
 tedge-rugix-core = { git = "https://github.com/thin-edge/tedge-rugix-core.git", branch = "v0.8-rugix" }

--- a/rugix-bakery.toml
+++ b/rugix-bakery.toml
@@ -1,8 +1,17 @@
 #:schema https://raw.githubusercontent.com/rugix/rugix-bakery/refs/tags/v0.9.0/schemas/rugix-bakery-project.schema.json
 [repositories]
-rugix-extra = { git = "https://github.com/silitics/rugix-extra", branch = "main" }
-tedge-rugix-core = { git = "https://github.com/thin-edge/tedge-rugix-core.git", branch = "v0.8-rugix" }
+rugix-extra = { git = "https://github.com/rugix/rugix-extra", branch = "main" }
+tedge-rugix-core = { git = "https://github.com/thin-edge/tedge-rugix-core.git", branch = "v0.9" }
 
+[systems.tedge-debian-13-efi-arm64]
+layer = "tedge-debian-13-efi"
+architecture = "arm64"
+target = "generic-grub-efi"
+
+[systems.tedge-debian-13-efi-amd64]
+layer = "tedge-debian-13-efi"
+architecture = "amd64"
+target = "generic-grub-efi"
 
 [systems.tedge-debian-12-efi-arm64]
 layer = "tedge-debian-12-efi"

--- a/run-bakery
+++ b/run-bakery
@@ -2,7 +2,25 @@
 
 set -euo pipefail
 
-DOCKER=${DOCKER:-"docker"}
+if command -v podman >/dev/null 2>&1 && [ -z "${DOCKER:-}" ]; then
+    echo ">>> Using podman as the container runtime." >&2
+    DOCKER="podman"
+    RUGIX_PRIVILEGED=${RUGIX_PRIVILEGED:-"false"}
+else
+    DOCKER=${DOCKER:-"docker"}
+    RUGIX_PRIVILEGED=${RUGIX_PRIVILEGED:-"true"}
+fi
+
+# macOS always requires privileged mode
+if [ "$(uname -s)" = "Darwin" ]; then
+    RUGIX_PRIVILEGED="true"
+fi
+
+if [ "${RUGIX_PRIVILEGED}" = "false" ]; then
+    echo ">>> Running without extended privileges." >&2
+    RUGIX_PRIVILEGED="false"
+fi
+
 DOCKER_FLAGS=${DOCKER_FLAGS:-""}
 
 RUGIX_DEV=${RUGIX_DEV:-"false"}
@@ -12,12 +30,12 @@ RUGIX_CONTEXT_DIR=${RUGIX_CONTEXT_DIR:-""}
 RUGIX_CACHE_VOLUME=${RUGIX_CACHE_VOLUME:-"rugix-build-cache"}
 
 if [ "${RUGIX_DEV}" = "false" ]; then
-    RUGIX_VERSION=${RUGIX_VERSION:-"v0.8"}
+    RUGIX_VERSION=${RUGIX_VERSION:-"v0.9"}
 else
     RUGIX_VERSION=${RUGIX_VERSION:-"dev"}
 fi
 
-RUGIX_BAKERY_IMAGE=${RUGIX_BAKERY_IMAGE:-"ghcr.io/silitics/rugix-bakery:${RUGIX_VERSION}"}
+RUGIX_BAKERY_IMAGE=${RUGIX_BAKERY_IMAGE:-"ghcr.io/rugix/rugix-bakery:${RUGIX_VERSION}"}
 
 if [ "${RUGIX_DEV}" = "false" ]; then
     $DOCKER pull "${RUGIX_BAKERY_IMAGE}"
@@ -30,20 +48,36 @@ if [ -t 0 ] && [ -t 1 ]; then
 fi
 
 if [ -n "${RUGIX_CACHE_VOLUME}" ]; then
-    $DOCKER volume create "${RUGIX_CACHE_VOLUME}" >/dev/null
+    if ! $DOCKER volume inspect "${RUGIX_CACHE_VOLUME}" >/dev/null 2>&1; then
+        $DOCKER volume create "${RUGIX_CACHE_VOLUME}" >/dev/null
+    fi
     DOCKER_FLAGS="${DOCKER_FLAGS} -v ${RUGIX_CACHE_VOLUME}:/run/rugix/bakery/cache"
 fi
 
 if [ "${1:-}" == "run" ]; then
     # Add port forwarding for SSH when running a system in a VM.
-    DOCKER_FLAGS="${DOCKER_FLAGS} -p 127.0.0.1:2222:2222 -p [::1]:2222:2222"
+    if [ "${DOCKER}" = "podman" ] && [ "$(uname -s)" = "Darwin" ]; then
+        # Podman on macOS cannot handle binding the same port twice.
+        DOCKER_FLAGS="${DOCKER_FLAGS} -p 127.0.0.1:2222:2222"
+    else
+        DOCKER_FLAGS="${DOCKER_FLAGS} -p 127.0.0.1:2222:2222 -p [::1]:2222:2222"
+    fi
 fi
 
-exec $DOCKER run --rm --privileged \
+PRIVILEGED_FLAG=""
+KVM_FLAG=""
+if [ "${RUGIX_PRIVILEGED}" = "true" ]; then
+    PRIVILEGED_FLAG="--privileged"
+elif [ -e /dev/kvm ]; then
+    KVM_FLAG="--device /dev/kvm"
+fi
+
+exec $DOCKER run --rm \
+    $PRIVILEGED_FLAG \
+    $KVM_FLAG \
     $DOCKER_FLAGS \
     -v "$(pwd)":/project \
     -v "$(pwd)/${RUGIX_CONTEXT_DIR}":/run/rugix/bakery/context \
-    -v /dev:/dev \
     -e "RUGIX_HOST_PROJECT_DIR=$(pwd)" \
     -e "RUGIX_BAKERY_IMAGE=${RUGIX_BAKERY_IMAGE}" \
     -e "RUGIX_DEV=${RUGIX_DEV}" \

--- a/systems.just
+++ b/systems.just
@@ -1,0 +1,33 @@
+# Auto generated: DO NOT EDIT
+
+# system: tedge-debian-13-efi-arm64
+tedge-debian-13-efi-arm64 type='image':
+    just SYSTEM=tedge-debian-13-efi-arm64 build-{{type}}
+
+# system: tedge-debian-13-efi-amd64
+tedge-debian-13-efi-amd64 type='image':
+    just SYSTEM=tedge-debian-13-efi-amd64 build-{{type}}
+
+# system: tedge-debian-12-efi-arm64
+tedge-debian-12-efi-arm64 type='image':
+    just SYSTEM=tedge-debian-12-efi-arm64 build-{{type}}
+
+# system: tedge-debian-12-efi-amd64
+tedge-debian-12-efi-amd64 type='image':
+    just SYSTEM=tedge-debian-12-efi-amd64 build-{{type}}
+
+# system: tedge-raspios-arm64-tryboot
+tedge-raspios-arm64-tryboot type='image':
+    just SYSTEM=tedge-raspios-arm64-tryboot build-{{type}}
+
+# system: tedge-raspios-arm64-tryboot-pi4
+tedge-raspios-arm64-tryboot-pi4 type='image':
+    just SYSTEM=tedge-raspios-arm64-tryboot-pi4 build-{{type}}
+
+# system: tedge-raspios-arm64
+tedge-raspios-arm64 type='image':
+    just SYSTEM=tedge-raspios-arm64 build-{{type}}
+
+# system: tedge-raspios-armhf
+tedge-raspios-armhf type='image':
+    just SYSTEM=tedge-raspios-armhf build-{{type}}


### PR DESCRIPTION
## Changes

### OS
- Raspberry Pi images now default to **Debian 13 (Trixie)**
- Enable Docker by default on Debian 13 (Trixie)
- Install Podman on `tedge-raspios-legacy` devices (Docker has deprecated support for older hardware)
- Enable the Podman socket service by default

### Containers
- Fix container Mosquitto listener being placed in a persisted directory, which could corrupt the root filesystem on rollback
- Remove persisted container listener on initialization
- Replace container Mosquitto listener with **nftables firewall rules**
- Enable nftables by default

### thin-edge.io
- Regenerate MQTT bridge configuration on health check to recover from stale state
- Health check now validates both the mapper URL and the MQTT endpoint
- Add post-commit hook to automatically upgrade the thin-edge.io config after a firmware update
- Fix tedge upgrade post-commit script

### Networking
- Use a drop-in override file for `systemd-resolved` configuration instead of modifying the main config

### New Recipes
- Add `set-root-password` recipe to allow setting a root password during image build

### Mosquitto
- Remove `include_dir` from the Mosquitto configuration to fix a startup issue

### CI / Build
- Update GitHub Actions
- Replace manual dependency installation with QEMU setup for cross-architecture builds
- Support controlling the container engine via the `DOCKER` variable
- Build and publish Debian 13 images in CI
